### PR TITLE
Docs detection

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,11 +3,11 @@ Installation
 
 Firstly, install postgreSQL and create a DB. Then, write in your terminal:
 
-.. code-block :: pycon
+.. code-block :: bash
 
-    >>> pip install -r requirements.txt
-    >>> export DATABASE_URL="postgresql:///[name]"
-    >>> export APP_SETTINGS="config.Config"
+    $ pip install -r requirements.txt
+    $ export DATABASE_URL="postgresql:///[name]"
+    $ export APP_SETTINGS="config.Config"
 
 To create the tables, enter python and type:
 

--- a/contact.py
+++ b/contact.py
@@ -34,7 +34,7 @@ def get_contact_for_user(owner):
 def get_contact_for_org(owner, repo_info):
 
     if repo_info:
-        if not repo_info['has_issues']:
+        if repo_info['has_issues']:
             contact = 'https://github.com/' + owner + '/' + repo + '/issues'
             return contact
         else:

--- a/docs.py
+++ b/docs.py
@@ -8,39 +8,46 @@ import re
 
 from contact import get_readme
 
-def has_docs(owner, repo):
-    url = 'https://github.com/' + owner + '/' + repo + '/tree/master/doc'
-
+def detect_url(url):
     try:
         r = requests.get(url)
         r.raise_for_status()
         return True
     except requests.exceptions.RequestException:
-        try:
-            r = requests.get(url+'s')
-            r.raise_for_status()
+        return False
+
+def search_readme(readme, regex):
+    DOCS_REGEX = re.compile(regex)
+    docs = DOCS_REGEX.search(readme)
+    return (docs != None) and (docs.end() != 0)
+
+def has_docs(owner, repo):
+    prefix = 'https://github.com/' + owner + '/' + repo + '/tree/master/'
+    suffixes = [ 'doc', 'docs', 'Doc', 'Docs', 'documentation',
+            'documentations', 'Documentation', 'Documentations' 'DOC', 'DOCS',
+            'DOCUMENTATION', 'DOCUMENTATIONS' ]
+
+    for suffix in suffixes:
+        if detect_url(prefix + suffix):
             return True
-        except requests.exceptions.RequestException:
-            # parse Readme file
-            #DOCS_REGEX = re.compile('[^a-zA-Z]Documentation[^a-zA-Z]')
 
-            DOCS_REGEX = re.compile('### Documentation\s')
-            readme = get_readme(owner, repo)
-            docs = DOCS_REGEX.search(readme)
+    readme = get_readme(owner, repo)
+    regexes = [ 'doc', 'docs', 'Doc', 'Docs', 'documentation',
+            'documentations', 'Documentation', 'Documentations' 'DOC', 'DOCS',
+            'DOCUMENTATION', 'DOCUMENTATIONS' ]
+    for regex in regexes:
+        if search_readme(readme, '### ' + regex + '\s'):
+            return True
 
-            return (docs != None) and (docs.end() != 0)
-'''
-            if docs.end() != 0:
-                return True
-            else:
-                docs = DOCS_REGEX.search(readme)
-'''
+    return False
 
 # tests
+def run_tests():
+    assert True == has_docs("mathemage", "Matrixpp"), "mathemage/Matrixpp"              # docs/
+    assert True == has_docs("MSusik", "beard"), "MSusik/beard"                          # doc/
+    assert True == has_docs("RocketChat", "Rocket.Chat"), "RocketChat/Rocket.Chat"      # "Documentation" in README.md
+    assert False == has_docs("dzenbot", "dznemptydataset"), "dzenbot/dznemptydataset"   # documention undetected yet available
+    assert False == has_docs("MSusik", "matraz"), "MSusik/matraz"                       # nothing
+
 if __name__ == "__main__":
-    #print has_docs(sys.argv[1], sys.argv[2])
-    print "mathemage", "Matrixpp",     has_docs("mathemage", "Matrixpp")      # docs/
-    print "MSusik", "beard",           has_docs("MSusik", "beard")            # doc/
-    print "MSusik", "matraz",          has_docs("MSusik", "matraz")           # nothing
-    print "dzenbot", "dznemptydataset",has_docs("dzenbot", "dznemptydataset") # we cannot find it, but it's there
-    print "RocketChat", "Rocket.Chat" ,has_docs("RocketChat", "Rocket.Chat")  # "Documentation" in README.md
+    run_tests()

--- a/docs.py
+++ b/docs.py
@@ -1,0 +1,43 @@
+'''
+import base64
+import json
+'''
+import sys
+import requests
+import re
+
+from contact import get_readme
+
+def has_docs(owner, repo):
+    url = 'https://github.com/' + owner + '/' + repo + '/tree/master/doc'
+
+    try:
+        r = requests.get(url)
+        r.raise_for_status()
+        return True
+    except requests.exceptions.RequestException:
+        try:
+            r = requests.get(url+'s')
+            r.raise_for_status()
+            return True
+        except requests.exceptions.RequestException:
+            # parse Readme file
+            #DOCS_REGEX = re.compile('[^a-zA-Z]Documentation[^a-zA-Z]')
+            DOCS_REGEX = re.compile('### Documentation\s')
+            readme = get_readme(owner, repo)
+            docs = DOCS_REGEX.search(readme)
+
+            return docs.end() == 0
+'''
+            if docs.end() != 0:
+                return True
+            else:
+                docs = DOCS_REGEX.search(readme)
+'''
+
+if __name__ == "__main__":
+    #print has_docs(sys.argv[1], sys.argv[2])
+    print "mathemage", "Matrixpp",     has_docs("mathemage", "Matrixpp")
+    print "MSusik", "beard",           has_docs("MSusik", "beard")
+    print "MSusik", "matraz",          has_docs("MSusik", "matraz")
+    print "dzenbot", "dznemptydataset",has_docs("dzenbot", "dznemptydataset")

--- a/docs.py
+++ b/docs.py
@@ -1,7 +1,3 @@
-'''
-import base64
-import json
-'''
 import sys
 import requests
 import re

--- a/docs.py
+++ b/docs.py
@@ -23,11 +23,12 @@ def has_docs(owner, repo):
         except requests.exceptions.RequestException:
             # parse Readme file
             #DOCS_REGEX = re.compile('[^a-zA-Z]Documentation[^a-zA-Z]')
+
             DOCS_REGEX = re.compile('### Documentation\s')
             readme = get_readme(owner, repo)
             docs = DOCS_REGEX.search(readme)
 
-            return docs.end() == 0
+            return (docs != None) and (docs.end() != 0)
 '''
             if docs.end() != 0:
                 return True
@@ -35,9 +36,11 @@ def has_docs(owner, repo):
                 docs = DOCS_REGEX.search(readme)
 '''
 
+# tests
 if __name__ == "__main__":
     #print has_docs(sys.argv[1], sys.argv[2])
-    print "mathemage", "Matrixpp",     has_docs("mathemage", "Matrixpp")
-    print "MSusik", "beard",           has_docs("MSusik", "beard")
-    print "MSusik", "matraz",          has_docs("MSusik", "matraz")
-    print "dzenbot", "dznemptydataset",has_docs("dzenbot", "dznemptydataset")
+    print "mathemage", "Matrixpp",     has_docs("mathemage", "Matrixpp")      # docs/
+    print "MSusik", "beard",           has_docs("MSusik", "beard")            # doc/
+    print "MSusik", "matraz",          has_docs("MSusik", "matraz")           # nothing
+    print "dzenbot", "dznemptydataset",has_docs("dzenbot", "dznemptydataset") # we cannot find it, but it's there
+    print "RocketChat", "Rocket.Chat" ,has_docs("RocketChat", "Rocket.Chat")  # "Documentation" in README.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,6 @@ Flask-SQLAlchemy
 Jinja2
 SQLAlchemy
 psycopg2
+requests
+pyopenssl
+ndg-httpsclient


### PR DESCRIPTION
Detect by:
- polling URLs of type https://github.com/' + owner + '/' + repo + '/tree/master/' and prefixes 'doc', 'docs', ...
- searching through README for these words as a heading - feature available only for Markdown, README.md files, but can be easily changed and hand-tuned by making different regex
